### PR TITLE
Add dereliction layer

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
                 { source: "https://ccmap.github.io/data/land_claims.civmap.json", enabled_presentation: true },
                 { source: "https://ccmap.github.io/data/exclusion_zones.civmap.json", enabled_presentation: true },
                 { source: "https://ccmap.github.io/data/mts_plots.json", enabled_presentation: true },
+                { source: "https://ccmap.github.io/data/dereliction.json", enabled_presentation: false },
                 { source: "https://ccmap.github.io/data/settlements.civmap.json", enabled_presentation: false },
                 { source: "https://ccmap.github.io/data/rails.civmap.json", enabled_presentation: false },
                 { source: "https://ameliorate.github.io/KANI/ccmap.json", enabled_presentation: false },


### PR DESCRIPTION
This allows ccmap.github.io to display the Dereliction Requests layer.

This won't work until ccmap/data/dereliction.json gets merged. Do not merge this until that happens.